### PR TITLE
Use non-strongname StackExchange.Redis

### DIFF
--- a/src/TagCache.Redis.FastJson/TagCache.Redis.FastJson.csproj
+++ b/src/TagCache.Redis.FastJson/TagCache.Redis.FastJson.csproj
@@ -34,9 +34,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\fastJSON.2.1.9.0\lib\net40\fastjson.dll</HintPath>
     </Reference>
-    <Reference Include="StackExchange.Redis.StrongName, Version=1.0.316.0, Culture=neutral, PublicKeyToken=c219ff1ca8c2ce46, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\StackExchange.Redis.StrongName.1.0.394\lib\net45\StackExchange.Redis.StrongName.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.0.394\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/TagCache.Redis.FastJson/packages.config
+++ b/src/TagCache.Redis.FastJson/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="fastJSON" version="2.1.9.0" targetFramework="net45" />
-  <package id="StackExchange.Redis.StrongName" version="1.0.394" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.0.394" targetFramework="net45" />
 </packages>

--- a/src/TagCache.Redis.Json.Net/TagCache.Redis.Json.Net.csproj
+++ b/src/TagCache.Redis.Json.Net/TagCache.Redis.Json.Net.csproj
@@ -34,9 +34,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="StackExchange.Redis.StrongName, Version=1.0.316.0, Culture=neutral, PublicKeyToken=c219ff1ca8c2ce46, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\StackExchange.Redis.StrongName.1.0.394\lib\net45\StackExchange.Redis.StrongName.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.0.394\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/TagCache.Redis.Json.Net/packages.config
+++ b/src/TagCache.Redis.Json.Net/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="StackExchange.Redis.StrongName" version="1.0.394" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.0.394" targetFramework="net45" />
 </packages>

--- a/src/TagCache.Redis.MessagePack/TagCache.Redis.MessagePack.csproj
+++ b/src/TagCache.Redis.MessagePack/TagCache.Redis.MessagePack.csproj
@@ -34,9 +34,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\MsgPack.Cli.0.5.10\lib\net45\MsgPack.dll</HintPath>
     </Reference>
-    <Reference Include="StackExchange.Redis.StrongName, Version=1.0.316.0, Culture=neutral, PublicKeyToken=c219ff1ca8c2ce46, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\StackExchange.Redis.StrongName.1.0.394\lib\net45\StackExchange.Redis.StrongName.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.0.394\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/TagCache.Redis.MessagePack/packages.config
+++ b/src/TagCache.Redis.MessagePack/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MsgPack.Cli" version="0.5.10" targetFramework="net45" />
-  <package id="StackExchange.Redis.StrongName" version="1.0.394" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.0.394" targetFramework="net45" />
 </packages>

--- a/src/TagCache.Redis.Migrant/TagCache.Redis.Migrant.csproj
+++ b/src/TagCache.Redis.Migrant/TagCache.Redis.Migrant.csproj
@@ -34,9 +34,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Migrant.0.9.4\lib\net40\Migrant.dll</HintPath>
     </Reference>
-    <Reference Include="StackExchange.Redis.StrongName, Version=1.0.316.0, Culture=neutral, PublicKeyToken=c219ff1ca8c2ce46, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\StackExchange.Redis.StrongName.1.0.394\lib\net45\StackExchange.Redis.StrongName.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.0.394\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/TagCache.Redis.Migrant/packages.config
+++ b/src/TagCache.Redis.Migrant/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Migrant" version="0.9.4" targetFramework="net45" />
-  <package id="StackExchange.Redis.StrongName" version="1.0.394" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.0.394" targetFramework="net45" />
 </packages>

--- a/src/TagCache.Redis.ProtoBuf/TagCache.Redis.ProtoBuf.csproj
+++ b/src/TagCache.Redis.ProtoBuf/TagCache.Redis.ProtoBuf.csproj
@@ -36,9 +36,9 @@
     <Reference Include="protobuf-net-data">
       <HintPath>..\packages\protobuf-net-data.2.0.7.668\lib\net45\protobuf-net-data.dll</HintPath>
     </Reference>
-    <Reference Include="StackExchange.Redis.StrongName, Version=1.0.316.0, Culture=neutral, PublicKeyToken=c219ff1ca8c2ce46, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\StackExchange.Redis.StrongName.1.0.394\lib\net45\StackExchange.Redis.StrongName.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.0.394\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/TagCache.Redis.ProtoBuf/packages.config
+++ b/src/TagCache.Redis.ProtoBuf/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="protobuf-net-data" version="2.0.7.668" targetFramework="net45" />
-  <package id="StackExchange.Redis.StrongName" version="1.0.394" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.0.394" targetFramework="net45" />
 </packages>

--- a/src/TagCache.Redis.Tests/TagCache.Redis.Tests.csproj
+++ b/src/TagCache.Redis.Tests/TagCache.Redis.Tests.csproj
@@ -55,9 +55,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
-    <Reference Include="StackExchange.Redis.StrongName, Version=1.0.316.0, Culture=neutral, PublicKeyToken=c219ff1ca8c2ce46, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\StackExchange.Redis.StrongName.1.0.394\lib\net45\StackExchange.Redis.StrongName.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.0.394\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.XML" />

--- a/src/TagCache.Redis.Tests/packages.config
+++ b/src/TagCache.Redis.Tests/packages.config
@@ -5,5 +5,5 @@
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
-  <package id="StackExchange.Redis.StrongName" version="1.0.394" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.0.394" targetFramework="net45" />
 </packages>

--- a/src/TagCache.Redis/TagCache.Redis.csproj
+++ b/src/TagCache.Redis/TagCache.Redis.csproj
@@ -31,9 +31,9 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StackExchange.Redis.StrongName, Version=1.0.316.0, Culture=neutral, PublicKeyToken=c219ff1ca8c2ce46, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\StackExchange.Redis.StrongName.1.0.394\lib\net45\StackExchange.Redis.StrongName.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.0.394\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/TagCache.Redis/packages.config
+++ b/src/TagCache.Redis/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StackExchange.Redis.StrongName" version="1.0.394" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.0.394" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Global update to nuget package references to StackExchange.Redis instead of StackExchange.Redis.StrongName. SE.Redis version remains 1.0.394.

fixes #11 